### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/donaghhorgan/ha-inworld-tts/security/code-scanning/1](https://github.com/donaghhorgan/ha-inworld-tts/security/code-scanning/1)

To fix the problem, set an explicit `permissions:` key at the root level of the workflow (since only one job exists, setting at the root impacts all jobs). Since none of the shown steps require any tokens that can modify code, issues, or pull requests, `contents: read` is the strictest viable starting point and is recommended by GitHub's own documentation for read-only workflows. 

Add the following block after the workflow name (`name: Lint`) and before the `on:` trigger:

```yaml
permissions:
  contents: read
```

No imports, method, or further definitions are required. Only a single code region in `.github/workflows/lint.yml` is modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
